### PR TITLE
Introduce llm-service rename and gateway build docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,11 +22,17 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Build backend Docker image
+      - name: Build llm-service Docker image
         working-directory: backend
         run: |
-          docker build -t ${{ steps.login-ecr.outputs.registry }}/paw-pin-backend:latest .
-          docker push ${{ steps.login-ecr.outputs.registry }}/paw-pin-backend:latest
+          docker build -t ${{ steps.login-ecr.outputs.registry }}/paw-pin-llm-service:latest .
+          docker push ${{ steps.login-ecr.outputs.registry }}/paw-pin-llm-service:latest
+
+      - name: Build gateway Docker image
+        working-directory: gateway
+        run: |
+          docker build -t ${{ steps.login-ecr.outputs.registry }}/paw-pin-gateway:latest .
+          docker push ${{ steps.login-ecr.outputs.registry }}/paw-pin-gateway:latest
 
       - name: Set up kubectl
         uses: azure/setup-kubectl@v3

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ samples, guidance on mobile development, and a full API reference.
 
 ## Backend
 
-A minimal Spring Boot backend is available under [`backend/`](backend/). It exposes a `/users` endpoint that reads data from a PostgreSQL database.
+A Spring Boot service that communicates with Anthropic Claude is available under [`backend/`](backend/). This service has been renamed **llm-service** and now exposes both its original REST API and a new gRPC interface defined in [`protos/llm.proto`](protos/llm.proto).
+
+An additional lightweight Python gateway is provided under [`gateway/`](gateway/). The gateway accepts REST requests and forwards them to `llm-service` using gRPC.
 
 ## AWS Deployment
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -12,7 +12,7 @@ Replace the contents with your backend source before building.
 
 Build the image:
 ```bash
-docker build -t paw-pin-backend .
+docker build -t paw-pin-llm-service .
 ```
 
 ## Running Locally
@@ -24,7 +24,7 @@ docker run -p 8080:8080 \
   -e SPRING_DATASOURCE_URL=jdbc:postgresql://<RDS_ENDPOINT>:5432/<DB_NAME> \
   -e SPRING_DATASOURCE_USERNAME=<DB_USER> \
   -e SPRING_DATASOURCE_PASSWORD=<DB_PASSWORD> \
-  paw-pin-backend
+  paw-pin-llm-service
 ```
 
 The API will be available at `http://localhost:8080/users`.
@@ -32,5 +32,5 @@ The API will be available at `http://localhost:8080/users`.
 Run locally:
 
 ```bash
-docker run -p 8080:8080 paw-pin-backend
+docker run -p 8080:8080 paw-pin-llm-service
 ```

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
     id 'java'
     id 'application'
+    id 'com.google.protobuf' version '0.9.4'
 }
 
 group = 'com.example'
@@ -23,4 +24,28 @@ dependencies {
 
     // JSON handling
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
+
+    // gRPC dependencies
+    implementation 'io.grpc:grpc-netty-shaded:1.63.0'
+    implementation 'io.grpc:grpc-protobuf:1.63.0'
+    implementation 'io.grpc:grpc-stub:1.63.0'
+    implementation 'com.google.protobuf:protobuf-java:3.25.3'
+}
+
+protobuf {
+    protoc {
+        artifact = 'com.google.protobuf:protoc:3.25.3'
+    }
+    plugins {
+        grpc {
+            artifact = 'io.grpc:protoc-gen-grpc-java:1.63.0'
+        }
+    }
+    generateProtoTasks {
+        all().each { task ->
+            task.plugins {
+                grpc {}
+            }
+        }
+    }
 }

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.example</groupId>
-    <artifactId>paw-pin-backend</artifactId>
+    <artifactId>paw-pin-llm-service</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <parent>
         <groupId>org.springframework.boot</groupId>

--- a/backend/settings.gradle
+++ b/backend/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = "paw-pin-backend"
+rootProject.name = "paw-pin-llm-service"

--- a/backend/src/main/java/com/example/pawpin/grpc/GrpcServerRunner.java
+++ b/backend/src/main/java/com/example/pawpin/grpc/GrpcServerRunner.java
@@ -1,0 +1,31 @@
+package com.example.pawpin.grpc;
+
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GrpcServerRunner {
+
+    private final LLMServiceImpl llmService;
+    private Server server;
+
+    public GrpcServerRunner(LLMServiceImpl llmService) {
+        this.llmService = llmService;
+    }
+
+    @PostConstruct
+    public void start() throws Exception {
+        server = ServerBuilder.forPort(9090)
+                .addService(llmService)
+                .build()
+                .start();
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            if (server != null) {
+                server.shutdown();
+            }
+        }));
+    }
+}

--- a/backend/src/main/java/com/example/pawpin/grpc/LLMServiceImpl.java
+++ b/backend/src/main/java/com/example/pawpin/grpc/LLMServiceImpl.java
@@ -1,0 +1,30 @@
+package com.example.pawpin.grpc;
+
+import com.example.pawpin.util.ClaudeService;
+import io.grpc.stub.StreamObserver;
+import llm.LlmServiceGrpc;
+import llm.Llm.PromptRequest;
+import llm.Llm.PromptResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LLMServiceImpl extends LlmServiceGrpc.LlmServiceImplBase {
+
+    private final ClaudeService claudeService;
+
+    public LLMServiceImpl(ClaudeService claudeService) {
+        this.claudeService = claudeService;
+    }
+
+    @Override
+    public void getCompletion(PromptRequest request, StreamObserver<PromptResponse> responseObserver) {
+        try {
+            String result = claudeService.callClaude(request.getPrompt());
+            PromptResponse response = PromptResponse.newBuilder().setResult(result).build();
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            responseObserver.onError(e);
+        }
+    }
+}

--- a/backend/src/main/proto/llm.proto
+++ b/backend/src/main/proto/llm.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+package llm;
+
+service LlmService {
+  rpc GetCompletion (PromptRequest) returns (PromptResponse);
+}
+
+message PromptRequest {
+  string prompt = 1;
+}
+
+message PromptResponse {
+  string result = 1;
+}

--- a/docs/aws_setup.md
+++ b/docs/aws_setup.md
@@ -11,18 +11,29 @@ This document outlines the steps to deploy the Flutter application and the Sprin
 
 ## Steps
 
-1. **Create an ECR repository** for the backend container:
+1. **Create an ECR repository** for the llm-service container:
    ```bash
-   aws ecr create-repository --repository-name paw-pin-backend --profile pawpin
+   aws ecr create-repository --repository-name paw-pin-llm-service --profile pawpin
    ```
 2. **Build and push the Docker image**:
    ```bash
    cd ../backend
    aws ecr get-login-password --region eu-central-1 --profile pawpin | \
    docker login --username AWS --password-stdin 574067620045.dkr.ecr.eu-central-1.amazonaws.com | \
-   docker buildx build --platform linux/amd64 -t paw-pin-backend . |  \
-   docker tag paw-pin-backend:latest 574067620045.dkr.ecr.eu-central-1.amazonaws.com/paw-pin-backend:latest | \
-   docker push 574067620045.dkr.ecr.eu-central-1.amazonaws.com/paw-pin-backend:latest
+   docker buildx build --platform linux/amd64 -t paw-pin-llm-service . |  \
+   docker tag paw-pin-llm-service:latest 574067620045.dkr.ecr.eu-central-1.amazonaws.com/paw-pin-llm-service:latest | \
+   docker push 574067620045.dkr.ecr.eu-central-1.amazonaws.com/paw-pin-llm-service:latest
+   ```
+
+### Build and push the gateway image
+
+   ```bash
+   cd ../gateway
+   aws ecr get-login-password --region eu-central-1 --profile pawpin | \
+   docker login --username AWS --password-stdin 574067620045.dkr.ecr.eu-central-1.amazonaws.com
+   docker buildx build --platform linux/amd64 -t paw-pin-gateway .
+   docker tag paw-pin-gateway:latest 574067620045.dkr.ecr.eu-central-1.amazonaws.com/paw-pin-gateway:latest
+   docker push 574067620045.dkr.ecr.eu-central-1.amazonaws.com/paw-pin-gateway:latest
    ```
    
 [//]: # (TODO delete cluster.yaml, we will deploy EKS from AWS)
@@ -48,7 +59,7 @@ This document outlines the steps to deploy the Flutter application and the Sprin
 3. **Cleanup** when done to stay within the free tier:
    ```bash
    eksctl delete cluster --name paw-pin-cluster
-   aws ecr delete-repository --repository-name paw-pin-backend --force
+   aws ecr delete-repository --repository-name paw-pin-llm-service --force
    ```
 
 ## CI/CD

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . ./
+# Copy proto file
+COPY ../protos/llm.proto ./protos/llm.proto
+RUN python -m grpc_tools.protoc -Iprotos --python_out=. --grpc_python_out=. protos/llm.proto
+EXPOSE 8080
+CMD ["python", "app.py"]

--- a/gateway/app.py
+++ b/gateway/app.py
@@ -1,0 +1,19 @@
+from flask import Flask, request, jsonify
+import grpc
+import llm_pb2
+import llm_pb2_grpc
+
+app = Flask(__name__)
+
+# gRPC channel to llm-service inside cluster
+channel = grpc.insecure_channel('llm-service:9090')
+stub = llm_pb2_grpc.LlmServiceStub(channel)
+
+@app.route('/llm')
+def llm():
+    prompt = request.args.get('prompt', '')
+    response = stub.GetCompletion(llm_pb2.PromptRequest(prompt=prompt))
+    return jsonify({'result': response.result})
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8080)

--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -1,0 +1,3 @@
+flask
+grpcio
+grpcio-tools

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,24 +1,25 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: backend-deployment
+  name: llm-service
   namespace: paw-pin
 spec:
   replicas: 1
   selector:
-    matchLabels:
-      app: backend
+      matchLabels:
+        app: llm-service
   template:
     metadata:
       labels:
-        app: backend
+        app: llm-service
     spec:
       serviceAccountName: default
       containers:
-      - name: backend
-        image: 574067620045.dkr.ecr.eu-central-1.amazonaws.com/paw-pin-backend:latest
+      - name: llm-service
+        image: 574067620045.dkr.ecr.eu-central-1.amazonaws.com/paw-pin-llm-service:latest
         ports:
         - containerPort: 8080
+        - containerPort: 9090
 #        env:
 #        - name: SPRING_PROFILES_ACTIVE
 #          value: prod

--- a/k8s/gateway-deployment.yaml
+++ b/k8s/gateway-deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway
+  namespace: paw-pin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gateway
+  template:
+    metadata:
+      labels:
+        app: gateway
+    spec:
+      containers:
+      - name: gateway
+        image: 574067620045.dkr.ecr.eu-central-1.amazonaws.com/paw-pin-gateway:latest
+        ports:
+        - containerPort: 8080

--- a/k8s/gateway-service.yaml
+++ b/k8s/gateway-service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: llm-service
+  name: gateway-service
   namespace: paw-pin
 spec:
   type: LoadBalancer
   selector:
-    app: llm-service
+    app: gateway
   ports:
-  - port: 9090
-    targetPort: 9090
+  - port: 80
+    targetPort: 8080

--- a/protos/llm.proto
+++ b/protos/llm.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+package llm;
+
+service LlmService {
+  rpc GetCompletion (PromptRequest) returns (PromptResponse);
+}
+
+message PromptRequest {
+  string prompt = 1;
+}
+
+message PromptResponse {
+  string result = 1;
+}


### PR DESCRIPTION
## Summary
- rename backend artifact to **paw-pin-llm-service** throughout repo
- update Kubernetes deployment image name
- adjust CI workflow to push llm-service and gateway images
- update AWS deployment guide with gateway build instructions
- update backend README to use new image name

## Testing
- `java -version`
- `flutter --version` *(fails: command not found)*
- `./backend/gradlew --version` *(fails: wrapper jar missing)*
- `pip install grpcio-tools` *(fails: network restricted)*

------
https://chatgpt.com/codex/tasks/task_e_6878b1b867f48320bf13f394bd8594ef