### PR TITLE
Add RDS and central gRPC services

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ samples, guidance on mobile development, and a full API reference.
 ## Backend
 
 A Spring Boot service that communicates with Anthropic Claude is available under [`backend/`](backend/). This service has been renamed **llm-service** and now exposes both its original REST API and a new gRPC interface defined in [`protos/llm.proto`](protos/llm.proto).
+A second microservice **rds-service** exposes gRPC CRUD operations for Items stored in PostgreSQL.
+A coordinating **central-service** aggregates llm and rds features into one gRPC API.
 
-An additional lightweight Python gateway is provided under [`gateway/`](gateway/). The gateway accepts REST requests and forwards them to `llm-service` using gRPC.
+An additional lightweight Python gateway is provided under [`gateway/`](gateway/). The gateway now forwards REST requests to a new **central-service**, which delegates calls to the existing **llm-service** and the new **rds-service**.
 
 ## AWS Deployment
 

--- a/central-service/.gitignore
+++ b/central-service/.gitignore
@@ -1,0 +1,40 @@
+/target
+# === Gradle ===
+.gradle/
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!gradle/wrapper/gradle-wrapper.properties
+
+# === IntelliJ IDEA ===
+.idea/
+*.iml
+*.ipr
+*.iws
+out/
+
+# === VS Code ===
+.vscode/
+
+# === System files ===
+.DS_Store
+Thumbs.db
+
+# === Logs and Temp ===
+*.log
+*.tmp
+*.swp
+
+# === OS/Editor backups ===
+*.bak
+*~
+*.orig
+
+# === Java ===
+*.class
+*.jar
+*.war
+*.ear
+
+# === Test reports ===
+test-results/
+test-output/

--- a/central-service/build.gradle
+++ b/central-service/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id 'org.springframework.boot' version '3.4.2'
+    id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'com.google.protobuf' version '0.9.4'
+}
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = '17'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'io.grpc:grpc-netty-shaded:1.63.0'
+    implementation 'io.grpc:grpc-protobuf:1.63.0'
+    implementation 'io.grpc:grpc-stub:1.63.0'
+    implementation 'com.google.protobuf:protobuf-java:3.25.3'
+    implementation 'javax.annotation:javax.annotation-api:1.3.2'
+}
+
+protobuf {
+    protoc {
+        artifact = 'com.google.protobuf:protoc:3.25.3'
+    }
+    plugins {
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.63.0' }
+    }
+    generateProtoTasks {
+        all().each { task ->
+            task.plugins { grpc {} }
+        }
+    }
+}

--- a/central-service/src/main/java/com/example/centralservice/CentralServiceApplication.java
+++ b/central-service/src/main/java/com/example/centralservice/CentralServiceApplication.java
@@ -1,0 +1,11 @@
+package com.example.centralservice;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class CentralServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(CentralServiceApplication.class, args);
+    }
+}

--- a/central-service/src/main/java/com/example/centralservice/grpc/CentralServiceImpl.java
+++ b/central-service/src/main/java/com/example/centralservice/grpc/CentralServiceImpl.java
@@ -1,0 +1,67 @@
+package com.example.centralservice.grpc;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.stub.StreamObserver;
+import llm.LlmServiceGrpc;
+import llm.Llm.PromptRequest;
+import llm.Llm.PromptResponse;
+import rds.RdsServiceGrpc;
+import rds.Rds.Item;
+import rds.Rds.ItemId;
+import com.google.protobuf.Empty;
+import central.CentralServiceGrpc;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CentralServiceImpl extends CentralServiceGrpc.CentralServiceImplBase {
+    private final LlmServiceGrpc.LlmServiceBlockingStub llmStub;
+    private final RdsServiceGrpc.RdsServiceBlockingStub rdsStub;
+
+    public CentralServiceImpl() {
+        ManagedChannel llmChannel = ManagedChannelBuilder.forAddress("llm-service", 9090)
+                .usePlaintext()
+                .build();
+        llmStub = LlmServiceGrpc.newBlockingStub(llmChannel);
+
+        ManagedChannel rdsChannel = ManagedChannelBuilder.forAddress("rds-service", 9091)
+                .usePlaintext()
+                .build();
+        rdsStub = RdsServiceGrpc.newBlockingStub(rdsChannel);
+    }
+
+    @Override
+    public void getCompletion(PromptRequest request, StreamObserver<PromptResponse> responseObserver) {
+        PromptResponse response = llmStub.getCompletion(request);
+        responseObserver.onNext(response);
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void createItem(Item request, StreamObserver<Item> responseObserver) {
+        Item response = rdsStub.createItem(request);
+        responseObserver.onNext(response);
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void getItem(ItemId request, StreamObserver<Item> responseObserver) {
+        Item response = rdsStub.getItem(request);
+        responseObserver.onNext(response);
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void updateItem(Item request, StreamObserver<Item> responseObserver) {
+        Item response = rdsStub.updateItem(request);
+        responseObserver.onNext(response);
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void deleteItem(ItemId request, StreamObserver<Empty> responseObserver) {
+        rdsStub.deleteItem(request);
+        responseObserver.onNext(Empty.getDefaultInstance());
+        responseObserver.onCompleted();
+    }
+}

--- a/central-service/src/main/java/com/example/centralservice/grpc/GrpcServerRunner.java
+++ b/central-service/src/main/java/com/example/centralservice/grpc/GrpcServerRunner.java
@@ -1,0 +1,27 @@
+package com.example.centralservice.grpc;
+
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GrpcServerRunner {
+    private final CentralServiceImpl centralService;
+    private Server server;
+    public GrpcServerRunner(CentralServiceImpl centralService) { this.centralService = centralService; }
+
+    @PostConstruct
+    public void start() throws Exception {
+        server = ServerBuilder.forPort(9092)
+                .addService(centralService)
+                .build()
+                .start();
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            if (server != null) {
+                server.shutdown();
+            }
+        }));
+    }
+}

--- a/central-service/src/main/proto/central.proto
+++ b/central-service/src/main/proto/central.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+package central;
+
+import "llm.proto";
+import "rds.proto";
+import "google/protobuf/empty.proto";
+
+service CentralService {
+  rpc GetCompletion(llm.PromptRequest) returns (llm.PromptResponse);
+  rpc CreateItem(rds.Item) returns (rds.Item);
+  rpc GetItem(rds.ItemId) returns (rds.Item);
+  rpc UpdateItem(rds.Item) returns (rds.Item);
+  rpc DeleteItem(rds.ItemId) returns (google.protobuf.Empty);
+}

--- a/central-service/src/main/proto/llm.proto
+++ b/central-service/src/main/proto/llm.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+package llm;
+
+service LlmService {
+  rpc GetCompletion (PromptRequest) returns (PromptResponse);
+}
+
+message PromptRequest {
+  string prompt = 1;
+}
+
+message PromptResponse {
+  string result = 1;
+}

--- a/central-service/src/main/proto/rds.proto
+++ b/central-service/src/main/proto/rds.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+package rds;
+
+import "google/protobuf/empty.proto";
+
+message ItemId {
+  int64 id = 1;
+}
+
+message Item {
+  int64 id = 1;
+  string name = 2;
+}
+
+service RdsService {
+  rpc CreateItem(Item) returns (Item);
+  rpc GetItem(ItemId) returns (Item);
+  rpc UpdateItem(Item) returns (Item);
+  rpc DeleteItem(ItemId) returns (google.protobuf.Empty);
+}

--- a/central-service/src/main/resources/application.properties
+++ b/central-service/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+# central service has no persistence properties

--- a/gateway/app.py
+++ b/gateway/app.py
@@ -1,19 +1,45 @@
 from flask import Flask, request, jsonify
 import grpc
+import central_pb2
+import central_pb2_grpc
 import llm_pb2
-import llm_pb2_grpc
+import rds_pb2
 
 app = Flask(__name__)
 
-# gRPC channel to llm-service inside cluster
-channel = grpc.insecure_channel('llm-service:9090')
-stub = llm_pb2_grpc.LlmServiceStub(channel)
+# gRPC channel to central-service inside cluster
+channel = grpc.insecure_channel('central-service:9092')
+stub = central_pb2_grpc.CentralServiceStub(channel)
 
 @app.route('/llm')
 def llm():
     prompt = request.args.get('prompt', '')
     response = stub.GetCompletion(llm_pb2.PromptRequest(prompt=prompt))
     return jsonify({'result': response.result})
+
+@app.route('/items', methods=['POST'])
+def create_item():
+    data = request.get_json(force=True)
+    item = rds_pb2.Item(name=data.get('name', ''))
+    result = stub.CreateItem(item)
+    return jsonify({'id': result.id, 'name': result.name})
+
+@app.route('/items/<int:item_id>', methods=['GET'])
+def get_item(item_id):
+    result = stub.GetItem(rds_pb2.ItemId(id=item_id))
+    return jsonify({'id': result.id, 'name': result.name})
+
+@app.route('/items/<int:item_id>', methods=['PUT'])
+def update_item(item_id):
+    data = request.get_json(force=True)
+    item = rds_pb2.Item(id=item_id, name=data.get('name', ''))
+    result = stub.UpdateItem(item)
+    return jsonify({'id': result.id, 'name': result.name})
+
+@app.route('/items/<int:item_id>', methods=['DELETE'])
+def delete_item(item_id):
+    stub.DeleteItem(rds_pb2.ItemId(id=item_id))
+    return jsonify({'deleted': True})
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=8080)

--- a/gateway/protos/central.proto
+++ b/gateway/protos/central.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+package central;
+
+import "llm.proto";
+import "rds.proto";
+import "google/protobuf/empty.proto";
+
+service CentralService {
+  rpc GetCompletion(llm.PromptRequest) returns (llm.PromptResponse);
+  rpc CreateItem(rds.Item) returns (rds.Item);
+  rpc GetItem(rds.ItemId) returns (rds.Item);
+  rpc UpdateItem(rds.Item) returns (rds.Item);
+  rpc DeleteItem(rds.ItemId) returns (google.protobuf.Empty);
+}

--- a/gateway/protos/rds.proto
+++ b/gateway/protos/rds.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+package rds;
+
+import "google/protobuf/empty.proto";
+
+message ItemId {
+  int64 id = 1;
+}
+
+message Item {
+  int64 id = 1;
+  string name = 2;
+}
+
+service RdsService {
+  rpc CreateItem(Item) returns (Item);
+  rpc GetItem(ItemId) returns (Item);
+  rpc UpdateItem(Item) returns (Item);
+  rpc DeleteItem(ItemId) returns (google.protobuf.Empty);
+}

--- a/k8s/central-deployment.yaml
+++ b/k8s/central-deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: central-service
+  namespace: paw-pin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: central-service
+  template:
+    metadata:
+      labels:
+        app: central-service
+    spec:
+      containers:
+      - name: central-service
+        image: 574067620045.dkr.ecr.eu-central-1.amazonaws.com/paw-pin-central-service:latest
+        ports:
+        - containerPort: 9092

--- a/k8s/central-service.yaml
+++ b/k8s/central-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: central-service
+  namespace: paw-pin
+spec:
+  type: ClusterIP
+  selector:
+    app: central-service
+  ports:
+  - port: 9092
+    targetPort: 9092

--- a/k8s/rds-deployment.yaml
+++ b/k8s/rds-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rds-service
+  namespace: paw-pin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rds-service
+  template:
+    metadata:
+      labels:
+        app: rds-service
+    spec:
+      containers:
+      - name: rds-service
+        image: 574067620045.dkr.ecr.eu-central-1.amazonaws.com/paw-pin-rds-service:latest
+        ports:
+        - containerPort: 8081
+        - containerPort: 9091

--- a/k8s/rds-service.yaml
+++ b/k8s/rds-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rds-service
+  namespace: paw-pin
+spec:
+  type: ClusterIP
+  selector:
+    app: rds-service
+  ports:
+  - port: 9091
+    targetPort: 9091

--- a/protos/central.proto
+++ b/protos/central.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+package central;
+
+import "llm.proto";
+import "rds.proto";
+import "google/protobuf/empty.proto";
+
+service CentralService {
+  rpc GetCompletion(llm.PromptRequest) returns (llm.PromptResponse);
+  rpc CreateItem(rds.Item) returns (rds.Item);
+  rpc GetItem(rds.ItemId) returns (rds.Item);
+  rpc UpdateItem(rds.Item) returns (rds.Item);
+  rpc DeleteItem(rds.ItemId) returns (google.protobuf.Empty);
+}

--- a/protos/rds.proto
+++ b/protos/rds.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+package rds;
+
+import "google/protobuf/empty.proto";
+
+message ItemId {
+  int64 id = 1;
+}
+
+message Item {
+  int64 id = 1;
+  string name = 2;
+}
+
+service RdsService {
+  rpc CreateItem(Item) returns (Item);
+  rpc GetItem(ItemId) returns (Item);
+  rpc UpdateItem(Item) returns (Item);
+  rpc DeleteItem(ItemId) returns (google.protobuf.Empty);
+}

--- a/rds-service/.gitignore
+++ b/rds-service/.gitignore
@@ -1,0 +1,40 @@
+/target
+# === Gradle ===
+.gradle/
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!gradle/wrapper/gradle-wrapper.properties
+
+# === IntelliJ IDEA ===
+.idea/
+*.iml
+*.ipr
+*.iws
+out/
+
+# === VS Code ===
+.vscode/
+
+# === System files ===
+.DS_Store
+Thumbs.db
+
+# === Logs and Temp ===
+*.log
+*.tmp
+*.swp
+
+# === OS/Editor backups ===
+*.bak
+*~
+*.orig
+
+# === Java ===
+*.class
+*.jar
+*.war
+*.ear
+
+# === Test reports ===
+test-results/
+test-output/

--- a/rds-service/build.gradle
+++ b/rds-service/build.gradle
@@ -1,0 +1,43 @@
+plugins {
+    id 'org.springframework.boot' version '3.4.2'
+    id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'com.google.protobuf' version '0.9.4'
+}
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = '17'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'org.postgresql:postgresql'
+    implementation 'io.grpc:grpc-netty-shaded:1.63.0'
+    implementation 'io.grpc:grpc-protobuf:1.63.0'
+    implementation 'io.grpc:grpc-stub:1.63.0'
+    implementation 'com.google.protobuf:protobuf-java:3.25.3'
+    implementation 'javax.annotation:javax.annotation-api:1.3.2'
+}
+
+protobuf {
+    protoc {
+        artifact = 'com.google.protobuf:protoc:3.25.3'
+    }
+    plugins {
+        grpc {
+            artifact = 'io.grpc:protoc-gen-grpc-java:1.63.0'
+        }
+    }
+    generateProtoTasks {
+        all().each { task ->
+            task.plugins {
+                grpc {}
+            }
+        }
+    }
+}

--- a/rds-service/src/main/java/com/example/rdsservice/RdsServiceApplication.java
+++ b/rds-service/src/main/java/com/example/rdsservice/RdsServiceApplication.java
@@ -1,0 +1,11 @@
+package com.example.rdsservice;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class RdsServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(RdsServiceApplication.class, args);
+    }
+}

--- a/rds-service/src/main/java/com/example/rdsservice/grpc/GrpcServerRunner.java
+++ b/rds-service/src/main/java/com/example/rdsservice/grpc/GrpcServerRunner.java
@@ -1,0 +1,27 @@
+package com.example.rdsservice.grpc;
+
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GrpcServerRunner {
+    private final RdsServiceImpl rdsService;
+    private Server server;
+    public GrpcServerRunner(RdsServiceImpl rdsService) { this.rdsService = rdsService; }
+
+    @PostConstruct
+    public void start() throws Exception {
+        server = ServerBuilder.forPort(9091)
+                .addService(rdsService)
+                .build()
+                .start();
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            if (server != null) {
+                server.shutdown();
+            }
+        }));
+    }
+}

--- a/rds-service/src/main/java/com/example/rdsservice/grpc/RdsServiceImpl.java
+++ b/rds-service/src/main/java/com/example/rdsservice/grpc/RdsServiceImpl.java
@@ -1,0 +1,54 @@
+package com.example.rdsservice.grpc;
+
+import com.example.rdsservice.item.Item;
+import com.example.rdsservice.item.ItemRepository;
+import io.grpc.stub.StreamObserver;
+import com.google.protobuf.Empty;
+import rds.RdsServiceGrpc;
+import rds.Rds.ItemId;
+import rds.Rds;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RdsServiceImpl extends RdsServiceGrpc.RdsServiceImplBase {
+    private final ItemRepository repository;
+    public RdsServiceImpl(ItemRepository repository) { this.repository = repository; }
+
+    private Rds.Item toProto(Item item) {
+        return Rds.Item.newBuilder()
+                .setId(item.getId())
+                .setName(item.getName())
+                .build();
+    }
+
+    @Override
+    public void createItem(Rds.Item request, StreamObserver<Rds.Item> responseObserver) {
+        Item item = new Item();
+        item.setName(request.getName());
+        item = repository.save(item);
+        responseObserver.onNext(toProto(item));
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void getItem(ItemId request, StreamObserver<Rds.Item> responseObserver) {
+        repository.findById(request.getId()).ifPresent(item -> responseObserver.onNext(toProto(item)));
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void updateItem(Rds.Item request, StreamObserver<Rds.Item> responseObserver) {
+        Item item = repository.findById(request.getId()).orElseGet(Item::new);
+        item.setName(request.getName());
+        item = repository.save(item);
+        responseObserver.onNext(toProto(item));
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void deleteItem(ItemId request, StreamObserver<Empty> responseObserver) {
+        repository.deleteById(request.getId());
+        responseObserver.onNext(Empty.getDefaultInstance());
+        responseObserver.onCompleted();
+    }
+}

--- a/rds-service/src/main/java/com/example/rdsservice/item/Item.java
+++ b/rds-service/src/main/java/com/example/rdsservice/item/Item.java
@@ -1,0 +1,20 @@
+package com.example.rdsservice.item;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Item {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+}

--- a/rds-service/src/main/java/com/example/rdsservice/item/ItemRepository.java
+++ b/rds-service/src/main/java/com/example/rdsservice/item/ItemRepository.java
@@ -1,0 +1,5 @@
+package com.example.rdsservice.item;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface ItemRepository extends CrudRepository<Item, Long> {}

--- a/rds-service/src/main/proto/rds.proto
+++ b/rds-service/src/main/proto/rds.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+package rds;
+
+import "google/protobuf/empty.proto";
+
+message ItemId {
+  int64 id = 1;
+}
+
+message Item {
+  int64 id = 1;
+  string name = 2;
+}
+
+service RdsService {
+  rpc CreateItem(Item) returns (Item);
+  rpc GetItem(ItemId) returns (Item);
+  rpc UpdateItem(Item) returns (Item);
+  rpc DeleteItem(ItemId) returns (google.protobuf.Empty);
+}

--- a/rds-service/src/main/resources/application.properties
+++ b/rds-service/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/postgres}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME:postgres}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:postgres}


### PR DESCRIPTION
## Summary
- add `rds-service` microservice with CRUD gRPC endpoints for an `Item` entity
- add `central-service` microservice that aggregates calls to `llm-service` and `rds-service`
- update Python gateway to talk to `central-service` and expose item CRUD endpoints
- define new protobufs for rds and central services
- update Kubernetes manifests for the new services
- mention new services in README

## Testing
- `flutter test` *(fails: command not found)*
- `./gradlew test` in backend *(fails: gradle-wrapper.jar missing)*

------
https://chatgpt.com/codex/tasks/task_e_688b89ecddd4832084b0f3b438e2f97b